### PR TITLE
Fix download_crystal() is always terminated abnormally

### DIFF
--- a/lib/crystal_funcs.sh
+++ b/lib/crystal_funcs.sh
@@ -1,6 +1,6 @@
 function download_crystal() {
   # If a previous download does not exist, then always re-download
-  if [ ${force_fetch} = true ] || [ ! -f ${crystal_path}/$(crystal_download_file) ]; then
+  if [[ ${force_fetch} = true ]] || [ ! -f ${crystal_path}/$(crystal_download_file) ]; then
     clean_crystal_downloads
     crystal_changed=true
 


### PR DESCRIPTION
the function `download_crystal()` seems always ends abnormally because `$force_fetch` is not set. This change makes it pass even when `$force_fetch` is empty. I doubt if checking `$force_fetch` is required at all though.
