### PR TITLE
allow commands to contain spaces

### DIFF
--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -87,7 +87,7 @@ function clean_cache() {
 }
 
 function exec_commands() {
-  for cmd in ${build_command[@]}; do
+  for cmd in "${build_command[@]}"; do
     $cmd
   done
 }


### PR DESCRIPTION
Hi,
I found this amazing repository in crystal-jp slack.

However, it causes an error to set `build_command=("crystal build --release src/foo.cr")` in my config file.
Heroku runs it as four commands: `crystal`, `build`, `--release`, `src/foo.cr`.
I'd like heroku to run it as one command, so fixed it.

We can run two commands or more by `build_command=("cmd1" "cmd2")`
